### PR TITLE
Feat rule order

### DIFF
--- a/surge3_rules
+++ b/surge3_rules
@@ -4,14 +4,16 @@
 RULE-SET,https://ruleset.dev/surge3_reject,AD Block
 RULE-SET,https://ruleset.dev/surge3_reject-tinygif,AD Block
 
-# Selectable
+# Pre-proxy Selectable
 RULE-SET,https://ruleset.dev/surge3_netease_music,Netease Music
 RULE-SET,https://ruleset.dev/surge3_stream_services,Stream Services
-RULE-SET,https://ruleset.dev/surge3_apple_services,Apple Services
 
 # Proxy
 RULE-SET,https://ruleset.dev/surge3_global_plus,rixCloud
 RULE-SET,https://ruleset.dev/surge3_global,rixCloud
+
+# Post-proxy Selectable
+RULE-SET,https://ruleset.dev/surge3_apple_services,Apple Services
 
 # Direct and Domestic
 RULE-SET,https://ruleset.dev/surge3_domestic,Domestic


### PR DESCRIPTION
# 优化规则序列顺序

## 现状与事实
与绝大多数网络 ACL 类似，Surge 亦遵循有序匹配-匹配即止原则，规则序列中靠前的条目相较于靠后者拥有更高的优先级。

surge3_global ([rixCloud-Surge3_Rules/Anti-GFW.list](https://github.com/rixCloud-Inc/rixCloud-Surge3_Rules/blob/master/Anti-GFW.list)) 中的 `>> Apple` 规则被设计用于匹配部分 Apple 在国内没有 CDN 覆盖的域名——例如 `audiocontentdownload.apple.com` 。

surge3_apple_services ([rixCloud-Surge3_Rules/Apple.list](https://github.com/rixCloud-Inc/rixCloud-Surge3_Rules/blob/master/Apple.list)) 被设计用于尽可能匹配所有由 Apple 提供的 / Apple 旗下的服务。为防遗漏，其中引入了 `DOMAIN-SUFFIX,apple.com,Apple Services` 条目，其将匹配包括但不限于 `audiocontentdownload.apple.com` 在内的诸多 `apple.com` 子域。

surge3_rules ([rixCloud_Surge-Data/surge3_rules](https://github.com/rixCloud-Inc/rixCloud_Surge-Data/blob/master/surge3_rules)) 中，`RULE-SET,https://ruleset.dev/surge3_apple_services,Apple Services` 处于 `RULE-SET,https://ruleset.dev/surge3_global,rixCloud` 之前，所有符合 `DOMAIN-SUFFIX,apple.com` 规则的流量都会被执行 `Apple Services` 策略，而不会继续向下尝试以至与 surge3_global (rixCloud-Surge3_Rules/Anti-GFW.list) 中的 `>> Apple` 规则匹配。此时，surge3_global (rixCloud-Surge3_Rules/Anti-GFW.list) 中 `>> Apple` 规则下的部分条目永远不会匹配到任何流量。

以 `audiocontentdownload.apple.com` 为例，该域名将会被执行 `Apple Services` 策略而不是直接执行 `rixCloud` 策略，如果此时的 `Apple Services` 没有被最终路由至 `rixCloud` 策略，surge3_global (rixCloud-Surge3_Rules/Anti-GFW.list) 中的 `>> Apple` 规则便失去了意义；而如果`Apple Services` 被最终路由至 `rixCloud` 策略，Apple Services 组便失去了意义。

## 解决
为 Rule 列表引入 Pre-proxy 和 Post-proxy 概念，对于匹配优先级比较高的 Netease Music 组和 Stream Services 组执行常代理组（rixCloud 组）前匹配，对于以匹配在国内可以良好访问的 Apple 服务所使用的域名为目的的 Apple Services 组执行常代理组（rixCloud 组）后匹配。

## 影响与效果
这一更改会导致如下规则由原来的执行 `Apple Services` 策略变为直接执行`rixCloud` 策略，符合 surge3_global (rixCloud-Surge3_Rules/Anti-GFW.list) 中 `>> Apple` 规则的设计本意。
```
DOMAIN,api-glb-sea.smoot.apple.com
DOMAIN,audiocontentdownload.apple.com
DOMAIN,beta.itunes.apple.com
DOMAIN,books.itunes.apple.com
DOMAIN,hls.itunes.apple.com
DOMAIN,itunes.apple.com
DOMAIN,lookup-api.apple.com
```
这一更改不会影响 Apple Services 组对其他 Apple 服务所用域名的匹配结果。

经测试，这一更改会大幅优化需要访问 `audiocontentdownload.apple.com` 等尚未在国内部署 CDN 的 Apple 服务的使用体验。