### PR TITLE
Update internet-test-url

### DIFF
--- a/surge3_general
+++ b/surge3_general
@@ -15,7 +15,7 @@ exclude-simple-hostnames = true
 always-real-ip = msftconnecttest.com, msftncsi.com, *.msftconnecttest.com, *.msftncsi.com
 network-framework = true 
 
-internet-test-url = http://www.aliyun.com
+internet-test-url = http://captive.apple.com
 proxy-test-url = http://captive.rixcloud.io/generate_204
 
 # macOS Only


### PR DESCRIPTION
Updated URL uses an Akamai’s CDN node, which has more BGP peers and a better global accessibility.